### PR TITLE
Add support for optional keySpace name

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = fig => {
   };
 
   const makeKey = (keySpace, key, cacheKeyFn) =>
-    `${keySpace}:${cacheKeyFn(key)}`;
+    `${keySpace ? keySpace + ':' : ''}${cacheKeyFn(key)}`;
 
   const rSetAndGet = (keySpace, key, rawVal, opt) =>
     toString(rawVal, opt).then(

--- a/test/test.js
+++ b/test/test.js
@@ -24,7 +24,7 @@ module.exports = ({ name, redis }) => {
 
       this.rGet = k =>
         new Promise((resolve, reject) => {
-          redis.get(k, (err, resp) => (err ? rejecte(err) : resolve(resp)));
+          redis.get(k, (err, resp) => (err ? reject(err) : resolve(resp)));
         });
 
       this.keySpace = 'key-space';
@@ -206,6 +206,22 @@ module.exports = ({ name, redis }) => {
           expect(data).to.be.instanceof(Date);
           expect(data.getTime()).to.equal(100);
         });
+      });
+
+      it('should handle optional keySpace', () => {
+        this.stubs.redisMGet = sinon.stub(redis, 'mget', (keys, cb) => {
+          cb(null, [JSON.stringify(this.data.json)]);
+        });
+
+        const loader = new RedisDataLoader(null, this.userLoader());
+
+        return loader
+          .load('foo')
+          .then(_ => {
+            expect(this.stubs.redisMGet.args[0][0]).to.deep.equal([
+              'foo',
+            ]);
+          });
       });
     });
 


### PR DESCRIPTION
### Description
Adds support for optional keySpace name. Right now, the keys will get prefixed with `:` if you leave the keySpace argument blank. I am using the `cacheKeyFn` to generate my keys, and I want to control the namespacing there instead.